### PR TITLE
Need to pass query string

### DIFF
--- a/03-routing/15-rewriting/page.md
+++ b/03-routing/15-rewriting/page.md
@@ -77,7 +77,7 @@ good for static files (images, css, js etc), and otherwise forward it on to the 
         server_name  www.mysite.com mysite.com;
         root         /path/www.mysite.com/public_html;
 
-        try_files $uri /index.php;
+        try_files $uri /index.php?$query_string;
 
         # this will only pass index.php to the fastcgi process which is generally safer but
         # assumes the whole site is run via Slim.


### PR DESCRIPTION
If you don't pass $query_string along with try_files, $_SERVER['QUERY_STRING'] ends up empty in PHP.  This causes Environment.php to calculate routes like "testfoo=bar", when it should be just "test".
