### PR TITLE
Fix missing $

### DIFF
--- a/11-flash-messages/01-overview/page.md
+++ b/11-flash-messages/01-overview/page.md
@@ -15,7 +15,7 @@ after a given event or error occurs.
 As shown below, the Slim application’s `flash()` and `flashNow()` methods accept two arguments: a key and a message.
 The key may be whatever you want and defines how the message will be accessed in the view templates. For example,
 if I invoke the Slim application’s `flash('foo', 'The foo message')` method with those arguments, I can access that
-message in the next request’s templates with `flash['foo']`.
+message in the next request’s templates with `$flash['foo']`.
 
 Flash messages are persisted with sessions; sessions are required for flash messages to work. Flash messages are
 stored in `$_SESSION['slim.flash']`.


### PR DESCRIPTION
flash['foo'] misses a $ in front.
