### PR TITLE
Clarify how group parameters are received by callables

### DIFF
--- a/03-routing/13-groups/page.md
+++ b/03-routing/13-groups/page.md
@@ -43,3 +43,20 @@ The routes defined above would be accessible at, respectively:
 
 Route groups are very useful to group related routes and avoid repeating common URL segments
 for each route definition.
+
+Parameters contained in the group portion of the route will be passed to the child routes like this:
+ 
+    <?php
+    $app = new \Slim\Slim();
+    
+    // Users group
+    $app->group('/users/:userId', function () use ($app) {
+
+        // User Posts group
+        $app->get('/posts/:postId', function ($userId, $postId) use ($app) {
+            
+            // this route can access both $userId and $postId
+            
+        }
+    }
+


### PR DESCRIPTION
Expand on the documentation for groups to clarify how parameters can be passed to groups. I expected to be able to receive them as parameters in the callable passed to the group method, but it turns out they are carried all the way to the final route callable. I think this change will make that more clear.
