### PR TITLE
Use `composer require` to install via composer.

### DIFF
--- a/01-getting-started/01-installation/page.md
+++ b/01-getting-started/01-installation/page.md
@@ -9,17 +9,9 @@ Install composer in your project:
 
     curl -s https://getcomposer.org/installer | php
 
-Create a `composer.json` file in your project root:
+Add the Slim framework as a dependency:
 
-    {
-        "require": {
-            "slim/slim": "2.*"
-        }
-    }
-
-Install via composer:
-
-    php composer.phar install
+    composer require "slim/slim"
 
 Add this line to your application's `index.php` file:
 


### PR DESCRIPTION
The recommended way to add a dependency to composer.son is to get the composer tool to do it for you. This PR updates the documentation to follow this.
